### PR TITLE
Disallow includeDesignDoc==false for paged /_all_docs queries

### DIFF
--- a/src/main/groovy/de/gesellix/couchdb/CouchDbClient.groovy
+++ b/src/main/groovy/de/gesellix/couchdb/CouchDbClient.groovy
@@ -242,7 +242,7 @@ class CouchDbClient {
 
   <T extends RowReference<String>, R extends NonReducedViewQueryResponse<String, T>> R getAllDocs(
       Type R, String db, String startkey, String startkeyDocId,
-      Integer limit = null, boolean includeDocs = true, boolean includeDesignDoc = false) {
+      Integer limit = null, boolean includeDocs = true, boolean includeDesignDoc = true) {
     List<String> query = []
     if (includeDocs) {
       query.add("include_docs=${includeDocs}")
@@ -281,12 +281,17 @@ class CouchDbClient {
     } else {
       R allDocs = json.consume(response.body().byteStream(), R)
       if (!includeDesignDoc) {
-        allDocs.rows.removeIf {
-//          if (it.id?.startsWith("_design/")) {
-//            log.info("removing $it")
-//          }
-          it.id?.startsWith("_design/")
-        }
+        log.warn(
+            "includeDesignDoc==false, but we're going to ignore the setting and retain _design/* documents in the result." +
+                "Please remove any _design/* documents in your application code.")
+        // Removing _design/* documents is disabled, because it would break the PagedViewIterator,
+        // which calculates `hasNext()` based on the difference of queried vs. returned number of rows.
+//        allDocs.rows.removeIf {
+////          if (it.id?.startsWith("_design/")) {
+////            log.info("removing $it")
+////          }
+//          it.id?.startsWith("_design/")
+//        }
       }
       return allDocs
     }


### PR DESCRIPTION
Removing _design/* documents is disabled for paged /_all_docs queries, because it would break the PagedViewIterator, which calculates `hasNext()` based on the difference of queried vs. returned number of rows.

