### PR TITLE
Disable fail-fast behaviour for failing Windows workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,5 @@ jobs:
       - name: clean build
         run: ./gradlew clean build --no-daemon --info --stacktrace
         timeout-minutes: 10
+        continue-on-error: ${{matrix.os == 'windows-latest' }}
 ...


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast and https://github.com/orgs/community/discussions/27192
